### PR TITLE
Use consistent interface for parsers

### DIFF
--- a/sentinel_config/parser.go
+++ b/sentinel_config/parser.go
@@ -1,0 +1,13 @@
+package sentinel_config
+
+import (
+	"github.com/glennsarti/sentinel-parser/diagnostics"
+
+	"github.com/glennsarti/sentinel-parser/sentinel_config/ast"
+)
+
+type Parser interface {
+	SentinelVersion() string
+
+	ParseFile(filename string, src []byte) (*ast.File, diagnostics.Diagnostics)
+}

--- a/sentinel_config/parser/parser.go
+++ b/sentinel_config/parser/parser.go
@@ -11,26 +11,30 @@ import (
 	"github.com/hashicorp/hcl/v2/hclparse"
 )
 
-type Parser struct {
+type parser struct {
 	p       *hclparse.Parser
 	version string
 }
 
-func NewParser(sentinelVersion string) (*Parser, error) {
+func newParser(sentinelVersion string) (*parser, error) {
 	ok, ver := features.ValidateSentinelVersion(sentinelVersion)
 	if !ok {
 		return nil, fmt.Errorf("%s is an invalid sentinel version", sentinelVersion)
 	}
 
-	return &Parser{
+	return &parser{
 		p:       hclparse.NewParser(),
 		version: ver,
 	}, nil
 }
 
-func (p *Parser) ParseFileSource(src []byte, path string) (*ast.File, diagnostics.Diagnostics) {
+func (p *parser) SentinelVersion() string {
+	return p.version
+}
+
+func (p *parser) ParseFile(filename string, src []byte) (*ast.File, diagnostics.Diagnostics) {
 	// Parse the HCL content
-	file, d := p.parseFileSource(src, path)
+	file, d := p.parseFileSource(src, filename)
 	diags := convertHclDiagnostics(d)
 	if diags != nil && diags.HasErrors() {
 		return nil, diags
@@ -40,12 +44,12 @@ func (p *Parser) ParseFileSource(src []byte, path string) (*ast.File, diagnostic
 		diags = diags.Add(&diagnostics.Diagnostic{
 			Severity: diagnostics.Error,
 			Summary:  "Failed to parse file",
-			Detail:   fmt.Sprintf("The file %q could not be parsed.", path),
+			Detail:   fmt.Sprintf("The file %q could not be parsed.", filename),
 		})
 		return nil, diags
 	}
 
-	// Parse the HCL content into a Sentinel File
+	// Parse the HCL content into a Sentinel Configuration File
 	configFile, e := parseConfigFile(file.Body, p.version)
 	diags = diags.Concat(e)
 	if diags != nil && diags.HasErrors() {
@@ -55,7 +59,7 @@ func (p *Parser) ParseFileSource(src []byte, path string) (*ast.File, diagnostic
 		diags = diags.Add(&diagnostics.Diagnostic{
 			Severity: diagnostics.Error,
 			Summary:  "Failed to parse file",
-			Detail:   fmt.Sprintf("The file %q could not be parse.", path),
+			Detail:   fmt.Sprintf("The file %q could not be parse.", filename),
 		})
 		return nil, diags
 	}
@@ -63,7 +67,7 @@ func (p *Parser) ParseFileSource(src []byte, path string) (*ast.File, diagnostic
 	return configFile, diags
 }
 
-func (p *Parser) parseFileSource(src []byte, path string) (*hcl.File, hcl.Diagnostics) {
+func (p *parser) parseFileSource(src []byte, path string) (*hcl.File, hcl.Diagnostics) {
 	switch {
 	case strings.HasSuffix(path, ".json"):
 		return p.p.ParseJSON(src, path)

--- a/sentinel_config/parser/public.go
+++ b/sentinel_config/parser/public.go
@@ -1,0 +1,32 @@
+package parser
+
+import (
+	"github.com/glennsarti/sentinel-parser/diagnostics"
+	"github.com/glennsarti/sentinel-parser/features"
+	"github.com/glennsarti/sentinel-parser/sentinel_config"
+	"github.com/glennsarti/sentinel-parser/sentinel_config/ast"
+)
+
+var _ sentinel_config.Parser = &parser{}
+
+func New(sentinelVersion string) (sentinel_config.Parser, error) {
+	if sentinelVersion == "" {
+		sentinelVersion = features.LatestSentinelVersion
+	}
+	return newParser(sentinelVersion)
+}
+
+func ParseFile(
+	sentinelVersion,
+	filename string,
+	src []byte,
+) (*ast.File, diagnostics.Diagnostics, error) {
+	p, err := New(sentinelVersion)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	r, diags := p.ParseFile(filename, src)
+
+	return r, diags, nil
+}

--- a/sentinel_config/serialization/spec/spec_test.go
+++ b/sentinel_config/serialization/spec/spec_test.go
@@ -153,14 +153,14 @@ func testSpecFile(filename, parentPath, sentinelVersion string, sut serializersU
 
 	t.Run(filename, func(t *testing.T) {
 		// Create the parser
-		hclParser, err := parser.NewParser(sentinelVersion)
+		hclParser, err := parser.New(sentinelVersion)
 		if err != nil {
 			t.Error(err)
 			return
 		}
 
 		// Parse it
-		expectedAst, diags := hclParser.ParseFileSource(inputFile.Data, archiveInputFile)
+		expectedAst, diags := hclParser.ParseFile(archiveInputFile, inputFile.Data)
 		if diags.HasErrors() {
 			t.Error(diags)
 			return

--- a/sentinel_config/spec/spec_test.go
+++ b/sentinel_config/spec/spec_test.go
@@ -260,15 +260,15 @@ type astResult struct {
 }
 
 func generateAST(sentinelVersion string, primary txtar.File, overrides []txtar.File) (*astResult, error) {
-	subject, err := parser.NewParser(sentinelVersion)
+	subject, err := parser.New(sentinelVersion)
 	if err != nil {
 		return nil, err
 	}
 
-	ast, diags := subject.ParseFileSource(primary.Data, primary.Name)
+	ast, diags := subject.ParseFile(primary.Name, primary.Data)
 
 	for _, f := range overrides {
-		otherAst, otherDiags := subject.ParseFileSource(f.Data, f.Name)
+		otherAst, otherDiags := subject.ParseFile(f.Name, f.Data)
 		diags = append(diags, otherDiags...)
 		otherDiags = parser.OverrideFileWith(ast, otherAst, sentinelVersion)
 		diags = append(diags, otherDiags...)


### PR DESCRIPTION
This commit updates the config parser and package to have similar interfaces